### PR TITLE
fix: dark mode contrast for buttons and UI elements

### DIFF
--- a/frontend/src/components/ConfirmDialog/ConfirmDialog.css
+++ b/frontend/src/components/ConfirmDialog/ConfirmDialog.css
@@ -14,7 +14,7 @@
     padding: 16px;
     min-width: 300px;
     width: fit-content;
-    background: #fff;
+    background: var(--dialog-bg);
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/frontend/src/components/GameConfigPanel/GameConfigPanel.css
+++ b/frontend/src/components/GameConfigPanel/GameConfigPanel.css
@@ -31,3 +31,7 @@
 .gameConfigButton {
     width: 80px;
 }
+
+.configCreationOnly {
+    background-color: var(--muted-bg);
+}

--- a/frontend/src/components/GameConfigPanel/GameConfigPanel.tsx
+++ b/frontend/src/components/GameConfigPanel/GameConfigPanel.tsx
@@ -143,7 +143,7 @@ function ConfigurationInput({ id, config, value, onChange, editting }: Configura
             );
         }
         return (
-            <tr style={{ backgroundColor: config.isCreationOnly ? "#e0e0e0" : undefined }}>
+            <tr className={config.isCreationOnly ? "configCreationOnly" : undefined}>
                 <td>{config.displayName}:</td>
                 <td>{valContent}</td>
                 <td>

--- a/frontend/src/components/InstanceTypeGuide/InstanceTypeGuide.css
+++ b/frontend/src/components/InstanceTypeGuide/InstanceTypeGuide.css
@@ -1,7 +1,7 @@
 .instanceTypeRoot {
     font-size: 14px;
     line-height: 1.6;
-    color: #1a1a1a;
+    color: var(--text-primary);
     max-width: 860px;
     padding: 0px;
 }
@@ -26,8 +26,8 @@
 }
 
 .instanceType-card {
-    background: #f9f9f9;
-    border: 1px solid #e5e5e5;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 16px;
 }
@@ -46,7 +46,7 @@
 
 .instanceType-cardWhen {
     font-size: 14px;
-    background: #f0f0f0;
+    background: var(--muted-bg);
     border-radius: 4px;
     padding: 8px 10px;
     line-height: 1.5;
@@ -57,7 +57,7 @@
     font-size: 14px;
     letter-spacing: 0.5px;
     text-transform: uppercase;
-    color: #555555;
+    color: var(--text-secondary);
     margin-bottom: 2px;
 }
 
@@ -75,7 +75,7 @@
 .instanceType-tableWrap {
     overflow-x: auto;
     border-radius: 6px;
-    border: 1px solid #e5e5e5;
+    border: 1px solid var(--border-color);
     margin-bottom: 12px;
 }
 
@@ -86,7 +86,7 @@
 }
 
 .instanceType-table thead tr {
-    background: #f5f5f5;
+    background: var(--muted-bg);
 }
 
 .instanceType-table th {
@@ -94,16 +94,16 @@
     font-weight: 600;
     letter-spacing: 1px;
     text-transform: uppercase;
-    color: #888;
+    color: var(--text-secondary);
     padding: 10px 14px;
     text-align: left;
     white-space: nowrap;
-    border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .instanceType-table td {
     padding: 10px 14px;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .instanceType-table tr:last-child td {
@@ -111,7 +111,7 @@
 }
 
 .instanceType-table tbody tr:hover td {
-    background: #fafafa;
+    background: var(--bg-surface-hover);
 }
 
 .instanceType-instanceName {
@@ -120,13 +120,13 @@
 
 .instanceType-note {
     font-size: 12px;
-    color: #666;
+    color: var(--text-secondary);
     line-height: 1.7;
     margin: 0;
 }
 
 .instanceType-note a {
-    color: #1a1a1a;
+    color: var(--text-primary);
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/Login/Login.css
+++ b/frontend/src/components/Login/Login.css
@@ -34,8 +34,14 @@
     padding: 16px;
     min-width: 300px;
     width: fit-content;
-    background: #fff;
+    background: var(--dialog-bg);
     display: flex;
     flex-direction: column;
     align-items: start;
+}
+
+.updateDialogPre {
+    padding: 10px;
+    background: var(--muted-bg);
+    border-radius: 5px;
 }

--- a/frontend/src/components/Login/Login.tsx
+++ b/frontend/src/components/Login/Login.tsx
@@ -159,7 +159,7 @@ function UpdateDialog(props: UpdateDialogProps) {
                     </a>
                 </div>
                 <div>2. Run this command</div>
-                <pre style={{ padding: "10px", background: "#f4f4f4", borderRadius: "5px" }}>
+                <pre className="updateDialogPre">
                     <code>{UPDATE_SCRIPT}</code>
                 </pre>
                 <button onClick={copyCallback}>{isCopied ? "Copied!" : "Copy"}</button>

--- a/frontend/src/components/PageSelector/PageSelector.css
+++ b/frontend/src/components/PageSelector/PageSelector.css
@@ -8,13 +8,13 @@
 
 .pageSelectorActive {
     padding: 6px 16px;
-    border: 1px solid #d0d0d0;
+    border: 1px solid var(--border-color);
     border-radius: 8px 8px 0 0;
-    background: white;
+    background: var(--bg-surface);
     font-weight: 600;
     font-size: 18px;
 
-    border-bottom-color: white;
+    border-bottom-color: var(--bg-surface);
     margin-bottom: -1px;
     z-index: 1;
 }
@@ -25,9 +25,9 @@
 
 .pageSelectorInactive {
     padding: 6px 16px;
-    border: 1px solid #d0d0d0;
+    border: 1px solid var(--border-color);
     border-radius: 8px 8px 0 0;
-    background: #f0f0f0;
+    background: var(--muted-bg);
     font-weight: 400;
     font-size: 18px;
 }

--- a/frontend/src/components/ServerTable/ServerTable.css
+++ b/frontend/src/components/ServerTable/ServerTable.css
@@ -3,13 +3,13 @@
     border-collapse: collapse;
 }
 .serverTable th {
-    border: 1px solid #acacac;
+    border: 1px solid var(--border-color);
     width: 1px;
     white-space: nowrap;
-    background-color: #cccccc;
+    background-color: var(--table-header-bg);
 }
 .serverTable td {
-    border: 1px solid #acacac;
+    border: 1px solid var(--border-color);
     width: 1px;
     white-space: nowrap;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,21 @@
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
 
+    --bg-surface: #2a2a2a;
+    --bg-surface-hover: #333;
+    --bg-card: #2a2a2a;
+    --border-color: #444;
+    --text-primary: rgba(255, 255, 255, 0.87);
+    --text-secondary: #aaa;
+    --btn-bg: #3a3a3a;
+    --btn-border: #555;
+    --btn-hover-border: #777;
+    --input-bg: #1a1a1a;
+    --table-header-bg: #333;
+    --dialog-bg: #2a2a2a;
+    --divider-color: #555;
+    --muted-bg: #333;
+
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -25,13 +40,14 @@ button {
     font-size: 1em;
     font-weight: 500;
     font-family: inherit;
-    background-color: #f0f0f0;
+    background-color: var(--btn-bg);
+    color: var(--text-primary);
     cursor: pointer;
     transition: border-color 0.25s;
-    border-color: #e2e2e2;
+    border-color: var(--btn-border);
 }
 button:hover {
-    border-color: #525252;
+    border-color: var(--btn-hover-border);
 }
 button:focus,
 button:focus-visible {
@@ -42,6 +58,21 @@ button:focus-visible {
     :root {
         color: #213547;
         background-color: #ffffff;
+
+        --bg-surface: #ffffff;
+        --bg-surface-hover: #f5f5f5;
+        --bg-card: #ffffff;
+        --border-color: #d0d0d0;
+        --text-primary: #213547;
+        --text-secondary: #666;
+        --btn-bg: #f0f0f0;
+        --btn-border: #e2e2e2;
+        --btn-hover-border: #525252;
+        --input-bg: #ffffff;
+        --table-header-bg: #cccccc;
+        --dialog-bg: #ffffff;
+        --divider-color: gray;
+        --muted-bg: #f0f0f0;
     }
 }
 

--- a/frontend/src/pages/CreateServerPage/CreateServerPage.css
+++ b/frontend/src/pages/CreateServerPage/CreateServerPage.css
@@ -41,7 +41,7 @@
 .createServerPageDivider {
     width: 100%;
     height: 1px;
-    background-color: black;
+    background-color: var(--divider-color);
     margin-bottom: 4px;
 }
 
@@ -51,4 +51,12 @@
 
 .createServerPageList {
     margin: 0px;
+}
+
+.createServerCreationOnlyHeader {
+    background-color: var(--muted-bg);
+}
+
+.createServerCreationOnly {
+    background-color: var(--muted-bg);
 }

--- a/frontend/src/pages/CreateServerPage/CreateServerPage.tsx
+++ b/frontend/src/pages/CreateServerPage/CreateServerPage.tsx
@@ -338,7 +338,7 @@ function CreateServerConfigurations({ game, configValues, setConfigValues }: Cre
                         <ConfigurationInput key={c.id} config={c} value={configValues[c.id]} onChange={(v) => onChange(c.id, v)} />
                     ))}
                     {createOnly.length > 0 && (
-                        <tr style={{ backgroundColor: "#e0e0e0" }}>
+                        <tr className="createServerCreationOnlyHeader">
                             <td colSpan={3}>Cannot be changed after creation:</td>
                         </tr>
                     )}
@@ -361,7 +361,7 @@ type ConfigurationInputProps = {
 function ConfigurationInput({ config, value, onChange }: ConfigurationInputProps) {
     if (config.type === "boolean") {
         return (
-            <tr style={{ backgroundColor: config.isCreationOnly ? "#e0e0e0" : undefined }}>
+            <tr className={config.isCreationOnly ? "createServerCreationOnly" : undefined}>
                 <td>{config.displayName}:</td>
                 <td>
                     <input
@@ -380,7 +380,7 @@ function ConfigurationInput({ config, value, onChange }: ConfigurationInputProps
     }
     if (config.type === "enum") {
         return (
-            <tr style={{ backgroundColor: config.isCreationOnly ? "#e0e0e0" : undefined }}>
+            <tr className={config.isCreationOnly ? "createServerCreationOnly" : undefined}>
                 <td>{config.displayName}:</td>
                 <td>
                     <select id={config.id} value={(value as string) ?? config.default} onChange={(e) => onChange(e.target.value)}>
@@ -398,7 +398,7 @@ function ConfigurationInput({ config, value, onChange }: ConfigurationInputProps
         );
     }
     return (
-        <tr style={{ backgroundColor: config.isCreationOnly ? "#e0e0e0" : undefined }}>
+        <tr className={config.isCreationOnly ? "createServerCreationOnly" : undefined}>
             <td>{config.displayName}:</td>
             <td>
                 <input

--- a/frontend/src/pages/ServerPage/ServerPage.css
+++ b/frontend/src/pages/ServerPage/ServerPage.css
@@ -6,7 +6,7 @@
 .pageDivider {
     width: 100%;
     height: 1px;
-    background-color: gray;
+    background-color: var(--divider-color);
     margin-top: 20px;
     margin-bottom: 20px;
 }

--- a/frontend/src/pages/UserPage/UserPage.css
+++ b/frontend/src/pages/UserPage/UserPage.css
@@ -12,6 +12,16 @@
     padding-bottom: 4px;
 }
 
+.userRowEditing {
+    background-color: #d4edda;
+}
+
+@media (prefers-color-scheme: dark) {
+    .userRowEditing {
+        background-color: #1a3a2a;
+    }
+}
+
 .userValue {
     text-align: start;
     font-weight: 600;

--- a/frontend/src/pages/UserPage/UserPage.tsx
+++ b/frontend/src/pages/UserPage/UserPage.tsx
@@ -116,7 +116,7 @@ function UserRow(props: RowProps) {
         [props.user.username, props.onUpdate],
     );
     return (
-        <div className="userRow" style={{ backgroundColor: props.editting ? "lightgreen" : "transparent" }}>
+        <div className={`userRow${props.editting ? " userRowEditing" : ""}`}>
             <div className="userValue">{props.user.username}</div>
             <select id={props.user.username} defaultValue={props.user.role} onChange={onChange} disabled={props.user.role === Role.Owner}>
                 {Object.values(Role).map((role) => (


### PR DESCRIPTION
Replaces hardcoded light-mode colors with CSS custom properties that adapt to `prefers-color-scheme`. Buttons, dialogs, tabs, tables, dividers, and inline styles now have proper contrast in both light and dark modes.

## Changes
- Added CSS custom properties in `index.css` for all theme colors
- Dark mode values as defaults, light mode values in `@media (prefers-color-scheme: light)`
- Updated 10 CSS files and 4 TSX files across 14 files total
- Moved inline `style` hardcoded colors to CSS classes for proper theming